### PR TITLE
Version of server and web bumped

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-ocv"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mina-ocv-web",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "engines": {
     "node": ">=18.0.0",


### PR DESCRIPTION
I forked the repository and edited the versions from `0.10.0` to `0.11.0` for the server and the web, so that the changes applied by Leandro could be automatically deployed on the staging environment: https://on-chain-voting-staging-devnet.minaprotocol.network/

- The version of the server is here: 
https://github.com/MinaFoundation/mina-on-chain-voting/blob/64b0905bbc93c6314247b5bce64746895446c405/server/Cargo.toml#L3C1-L3C19

- The version of the web is here: 
https://github.com/MinaFoundation/mina-on-chain-voting/blob/64b0905bbc93c6314247b5bce64746895446c405/web/package.json#L3