### PR TITLE
Staging deploy build fails: fix lint error

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren } from 'react';
 
 import { Metadata } from 'next';
-import { IBM_Plex_Mono, IBM_Plex_Sans } from 'next/font/google';
+import { IBM_Plex_Sans } from 'next/font/google';
 
 import { siteConfig } from 'common/config';
 import { cn } from 'common/utils';


### PR DESCRIPTION
Staging deployment fails due to a lint error:
 > [ 7/11] RUN pnpm build:
33.06 Failed to compile.
33.06 
33.06 ./app/layout.tsx
33.06 4:10  Error: 'IBM_Plex_Mono' is defined but never used.  unused-imports/no-unused-imports
33.06 
33.06 ./components/layout-nav-mobile.tsx
33.06 3:1  Warning: Run autofix to sort these imports!  simple-import-sort/imports
33.06 
33.06 info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules
33.16  ELIFECYCLE  Command failed with exit code 1.

