### PR TITLE
improve deterministic result - refactor

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1859,7 +1859,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mina-ocv"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "aws-sdk-s3",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-ocv"
-version = "0.14.4"
+version = "0.14.5"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Improve deterministic result for low votes count
https://github.com/orgs/MinaFoundation/projects/16/views/1?pane=issue&itemId=97249954&issue=MinaFoundation%7Cmina-on-chain-voting%7C86
Refactor, replace HashMap with BTreeMap 
+ prevent different orders accross runs
+ ensures that when candidates have the same vote count, they are processed in a predictable order